### PR TITLE
ドメインにハイフンが含まれていて、サブドメインが切られたメールアドレスの場合、正しくてもエラーが出てしまう問題を修正

### DIFF
--- a/lib/roshi/active_model/validations/email_validator.rb
+++ b/lib/roshi/active_model/validations/email_validator.rb
@@ -3,7 +3,7 @@ module ActiveModel
     class EmailValidator < EachValidator
       def validate_each(record, attribute, value)
         # http://emailregex.com
-        unless value =~ /\A([\w+!#$%&'*+\/=?^`{|}~\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
+        unless value =~ /\A([\w+!#$%&'*+\/=?^`{|}~\-].?)+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
           record.errors.add(attribute, options[:message] || I18n.t('errors.messages.invalid'))
         end
       end


### PR DESCRIPTION
`test@hoge.example-foo.com`の場合、正しくてもエラーが出てしまう問題を修正。
