### PR TITLE
[Renovate] Reject e-mail  including spaces

### DIFF
--- a/lib/roshi/active_model/validations/email_validator.rb
+++ b/lib/roshi/active_model/validations/email_validator.rb
@@ -3,7 +3,7 @@ module ActiveModel
     class EmailValidator < EachValidator
       def validate_each(record, attribute, value)
         # http://emailregex.com
-        unless value =~ /\A([\w+!#$%&'*+\/=?^`{|}~\-].?)+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+        unless value =~ URI::MailTo::EMAIL_REGEXP
           record.errors.add(attribute, options[:message] || I18n.t('errors.messages.invalid'))
         end
       end

--- a/spec/validations/email_validator_spec.rb
+++ b/spec/validations/email_validator_spec.rb
@@ -31,7 +31,8 @@ describe 'EmailValidator' do
       'email@',
       'email.example.com',
       'email@example..com',
-      'あいうえお@example.com'
+      'あいうえお@example.com',
+      'aaa aaa@example.com'
     ].each do |email|
       it "#{email} should be invalid" do
         expect(EmailModel.new(email: email)).not_to be_valid


### PR DESCRIPTION
## Overview
roshi's email validator accepted e-mail including spaces. For example, `aaa aaa@example.com`. 
This seemed bad for me.

Thats' why,  I suggest new email validator using `URI::MailTo::EMAIL_REGEXP`.
And, I added a test case hacking old validator.

Thank you for your review. 
